### PR TITLE
feat: throw error when accessing `model.$store` without store being injected

### DIFF
--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -1,5 +1,5 @@
 import { Store } from 'vuex'
-import { isArray } from '../support/Utils'
+import { isArray, assert } from '../support/Utils'
 import { Element, Item, Collection } from '../data/Data'
 import { Attribute } from './attributes/Attribute'
 import { Attr } from './attributes/types/Attr'
@@ -194,6 +194,12 @@ export class Model {
    * Get the store instance.
    */
   get $store(): Store<any> {
+    assert(this._store !== undefined, [
+      'The store instance is not injected into the model instance. You might',
+      'be trying to instantiate the model directly. Please use',
+      '`repository.make` method to create a new model instance.'
+    ])
+
     return this._store
   }
 

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -195,8 +195,8 @@ export class Model {
    */
   get $store(): Store<any> {
     assert(this._store !== undefined, [
-      'The store instance is not injected into the model instance. You might',
-      'be trying to instantiate the model directly. Please use',
+      'A Vuex Store instance is not injected into the model instance.',
+      'You might be trying to instantiate the model directly. Please use',
       '`repository.make` method to create a new model instance.'
     ])
 

--- a/src/support/Utils.ts
+++ b/src/support/Utils.ts
@@ -198,3 +198,13 @@ export function cloneDeep<T extends object>(target: T): T {
 
   return target
 }
+
+/**
+ * Check for the given condition, and if it's `false`, it will throw a new
+ * error with the given message.
+ */
+export function assert(condition: boolean, message: string[]): void {
+  if (!condition) {
+    throw new Error(['[Vuex ORM]'].concat(message).join(' '))
+  }
+}

--- a/test/unit/model/Model.spec.ts
+++ b/test/unit/model/Model.spec.ts
@@ -1,0 +1,11 @@
+import { Model } from '@/model/Model'
+
+describe('unit/model/Model', () => {
+  class User extends Model {
+    static entity = 'users'
+  }
+
+  it('throws when accessing the store but it is not injected', () => {
+    expect(() => new User().$store).toThrow()
+  })
+})


### PR DESCRIPTION
Throw when user accesses the `model.$store` function without having store injected. This happens when user tries to do `new User().$store` kinda thing. Users should be directed to use `repository.make()` method instead.

#### Type of PR:

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Code style update
- [ ] Build-related changes
- [ ] Test
- [ ] Documentation
- [ ] Other, please describe: