### PR TITLE
feat: `orderBy` supports passing a handler as a field param

### DIFF
--- a/src/query/Options.ts
+++ b/src/query/Options.ts
@@ -1,9 +1,9 @@
 import { Model } from '../model/Model'
 import { Query } from './Query'
 
-export interface Where<M extends Model, T extends keyof M> {
-  field: WherePrimaryClosure<M> | T
-  value: WhereSecondaryClosure<M, T> | M[T] | M[T][]
+export interface Where<M extends Model, K extends keyof M> {
+  field: WherePrimaryClosure<M> | K
+  value: WhereSecondaryClosure<M, K> | M[K] | M[K][]
   boolean: 'and' | 'or'
 }
 
@@ -13,15 +13,17 @@ export type WhereSecondaryClosure<M extends Model, K extends keyof M> = (
   value: M[K]
 ) => boolean
 
-export interface WhereGroup<M extends Model, T extends keyof M> {
-  and?: Where<M, T>[]
-  or?: Where<M, T>[]
+export interface WhereGroup<M extends Model, K extends keyof M> {
+  and?: Where<M, K>[]
+  or?: Where<M, K>[]
 }
 
-export interface Order {
-  field: string
+export interface Order<M extends Model> {
+  field: OrderBy<M>
   direction: OrderDirection
 }
+
+export type OrderBy<M extends Model> = string | ((model: M) => any)
 
 export type OrderDirection = 'asc' | 'desc'
 

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -23,6 +23,7 @@ import {
   WherePrimaryClosure,
   WhereSecondaryClosure,
   Order,
+  OrderBy,
   OrderDirection,
   EagerLoad,
   EagerLoadConstraint,
@@ -63,7 +64,7 @@ export class Query<M extends Model = Model> {
   /**
    * The orderings for the query.
    */
-  protected orders: Order[] = []
+  protected orders: Order<M>[] = []
 
   /**
    * The maximum number of records to return.
@@ -148,7 +149,7 @@ export class Query<M extends Model = Model> {
   /**
    * Add an "order by" clause to the query.
    */
-  orderBy(field: string, direction: OrderDirection = 'asc'): Query<M> {
+  orderBy(field: OrderBy<M>, direction: OrderDirection = 'asc'): Query<M> {
     this.orders.push({ field, direction })
 
     return this

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -7,7 +7,8 @@ import { Query } from '../query/Query'
 import {
   WherePrimaryClosure,
   WhereSecondaryClosure,
-  OrderDirection
+  OrderDirection,
+  OrderBy
 } from '../query/Options'
 
 export class Repository<M extends Model = Model> {
@@ -119,7 +120,7 @@ export class Repository<M extends Model = Model> {
   /**
    * Add an "order by" clause to the query.
    */
-  orderBy(field: string, direction?: OrderDirection): Query<M> {
+  orderBy(field: OrderBy<M>, direction?: OrderDirection): Query<M> {
     return this.query().orderBy(field, direction)
   }
 

--- a/src/support/Utils.ts
+++ b/src/support/Utils.ts
@@ -60,7 +60,7 @@ export function orderBy<T>(
 ): T[] {
   let index = -1
 
-  const result = collection.map((value) => {
+  const result = collection.map<SortableArray<T>>((value) => {
     const criteria = iteratees.map((iteratee) => {
       return typeof iteratee === 'function' ? iteratee(value) : value[iteratee]
     })
@@ -88,9 +88,11 @@ function baseSortBy<T>(
   array.sort(comparer)
 
   const newArray: T[] = []
+
   while (length--) {
     newArray[length] = array[length].value
   }
+
   return newArray
 }
 
@@ -102,7 +104,7 @@ function baseSortBy<T>(
  * Otherwise, specify an order of "desc" for descending or "asc" for
  * ascending sort order of corresponding values.
  */
-function compareMultiple(object: any, other: any, orders: string[]): number {
+function compareMultiple<T>(object: SortableArray<T>, other: SortableArray<T>, directions: string[]): number {
   let index = -1
 
   const objCriteria = object.criteria
@@ -113,9 +115,9 @@ function compareMultiple(object: any, other: any, orders: string[]): number {
     const result = compareAscending(objCriteria[index], othCriteria[index])
 
     if (result) {
-      const order = orders[index]
+      const direction = directions[index]
 
-      return result * (order === 'desc' ? -1 : 1)
+      return result * (direction === 'desc' ? -1 : 1)
     }
   }
 

--- a/src/support/Utils.ts
+++ b/src/support/Utils.ts
@@ -104,7 +104,11 @@ function baseSortBy<T>(
  * Otherwise, specify an order of "desc" for descending or "asc" for
  * ascending sort order of corresponding values.
  */
-function compareMultiple<T>(object: SortableArray<T>, other: SortableArray<T>, directions: string[]): number {
+function compareMultiple<T>(
+  object: SortableArray<T>,
+  other: SortableArray<T>,
+  directions: string[]
+): number {
   let index = -1
 
   const objCriteria = object.criteria

--- a/test/feature/repository/retrieves_order_by.spec.ts
+++ b/test/feature/repository/retrieves_order_by.spec.ts
@@ -15,7 +15,7 @@ describe('feature/repository/retrieves_order_by', () => {
     @Num(0) age!: number
   }
 
-  it('can sort the records by the `order by` clause', () => {
+  it('can sort records using the `orderBy` modifier', () => {
     const store = createStore()
 
     fillState(store, {
@@ -39,7 +39,7 @@ describe('feature/repository/retrieves_order_by', () => {
     assertModels(users, expected)
   })
 
-  it('can sort the records by "desc" order', () => {
+  it('can sort records in descending order', () => {
     const store = createStore()
 
     fillState(store, {
@@ -63,7 +63,7 @@ describe('feature/repository/retrieves_order_by', () => {
     assertModels(users, expected)
   })
 
-  it('can combine multiple orders', () => {
+  it('can sort records by combining multiple `orderBy` modifiers', () => {
     const store = createStore()
 
     fillState(store, {
@@ -87,6 +87,33 @@ describe('feature/repository/retrieves_order_by', () => {
     ]
 
     expect(users).toHaveLength(5)
+    assertInstanceOf(users, User)
+    assertModels(users, expected)
+  })
+
+  it('can sort records by specifying a callback', () => {
+    const store = createStore()
+
+    fillState(store, {
+      users: {
+        1: { id: 1, name: 'James', age: 40 },
+        2: { id: 2, name: 'Andy', age: 30 },
+        3: { id: 3, name: 'David', age: 20 }
+      }
+    })
+
+    const users = store
+      .$repo(User)
+      .orderBy((user) => user.age, 'desc')
+      .get()
+
+    const expected = [
+      { id: 1, name: 'James', age: 40 },
+      { id: 2, name: 'Andy', age: 30 },
+      { id: 3, name: 'David', age: 20 }
+    ]
+
+    expect(users).toHaveLength(3)
     assertInstanceOf(users, User)
     assertModels(users, expected)
   })


### PR DESCRIPTION

#### Type of PR:

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Code style update
- [ ] Build-related changes
- [ ] Test
- [ ] Documentation
- [ ] Other, please describe:

#### Breaking changes:

- [x] No
- [ ] Yes

### Details

Similar to the current feature, allow handlers to be passed into the field param for the `orderBy` modifier.


