### PR TITLE
fix(model): prevent `_store` from becoming a cyclic object value.

### DIFF
--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -61,6 +61,10 @@ export class Model {
     this.$boot()
 
     this.$fill(attributes, options)
+
+    // Prevent `_store` from becoming cyclic object value and causing
+    // v-bind side-effects by negating enumerability.
+    Object.defineProperty(this, '_store', { enumerable: false, writable: true })
   }
 
   /**


### PR DESCRIPTION
#### Type of PR:

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Code style update
- [ ] Build-related changes
- [ ] Test
- [ ] Documentation
- [ ] Other, please describe:

#### Breaking changes:

- [x] No
- [ ] Yes

### Details

This PR resolves #10 where a fortuitous side-effect is caused by model's exposing the `_store` property.