### PR TITLE
refactor: the way to attach foreign key to the relationships

### DIFF
--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -1,8 +1,7 @@
 import { normalize, schema as Normalizr } from 'normalizr'
 import { Store } from 'vuex'
 import { isArray, isEmpty } from '../support/Utils'
-import { Element, Elements, NormalizedData } from '../data/Data'
-import { Relation } from '../model/attributes/relations/Relation'
+import { Element, NormalizedData } from '../data/Data'
 import { Model } from '../model/Model'
 
 export class Interpreter<M extends Model> {
@@ -28,15 +27,7 @@ export class Interpreter<M extends Model> {
    * Perform interpretation for the given data.
    */
   process(data: Element | Element[]): NormalizedData {
-    if (isEmpty(data)) {
-      return {}
-    }
-
-    const normalizedData = this.normalize(data)
-
-    this.attach(normalizedData)
-
-    return normalizedData
+    return isEmpty(data) ? {} : this.normalize(data)
   }
 
   /**
@@ -53,50 +44,5 @@ export class Interpreter<M extends Model> {
    */
   private getSchema(): Normalizr.Entity {
     return this.store.$database.getSchema(this.model.$entity)
-  }
-
-  /**
-   * Attach any missing foreign keys to the data.
-   */
-  private attach(data: NormalizedData): void {
-    for (const entity in data) {
-      this.attachElements(entity, data[entity], data)
-    }
-  }
-
-  /**
-   * Attach any missing foreign keys to the records.
-   */
-  private attachElements(
-    entity: string,
-    records: Elements,
-    data: NormalizedData
-  ): void {
-    const model = this.store.$database.getModel(entity)
-
-    if (!model.$hasRelation()) {
-      return
-    }
-
-    for (const id in records) {
-      this.attachElement(model, records[id], data)
-    }
-  }
-
-  /**
-   * Attach any missing foreign keys to the record.
-   */
-  private attachElement(
-    model: Model,
-    record: Element,
-    data: NormalizedData
-  ): void {
-    for (const key in record) {
-      const attr = model.$fields[key]
-
-      if (attr instanceof Relation) {
-        attr.attach(record[key], record, data)
-      }
-    }
   }
 }

--- a/src/model/attributes/relations/BelongsTo.ts
+++ b/src/model/attributes/relations/BelongsTo.ts
@@ -1,6 +1,6 @@
 import { Schema as NormalizrSchema } from 'normalizr'
 import { Schema } from '../../../schema/Schema'
-import { Element, NormalizedData, Collection } from '../../../data/Data'
+import { Element, Collection } from '../../../data/Data'
 import { Query } from '../../../query/Query'
 import { Model } from '../../Model'
 import { Relation } from './Relation'
@@ -55,14 +55,10 @@ export class BelongsTo extends Relation {
   }
 
   /**
-   * Attach the relational key to the given data object.
+   * Attach the relational key to the given relation.
    */
-  attach(id: string | number, record: Element, data: NormalizedData): void {
-    const childRecord = data[this.child.$entity]?.[id]
-
-    if (childRecord) {
-      record[this.foreignKey] = childRecord[this.ownerKey]
-    }
+  attach(record: Element, child: Element): void {
+    record[this.foreignKey] = child[this.ownerKey]
   }
 
   /**

--- a/src/model/attributes/relations/HasMany.ts
+++ b/src/model/attributes/relations/HasMany.ts
@@ -1,6 +1,6 @@
 import { Schema as NormalizrSchema } from 'normalizr'
 import { Schema } from '../../../schema/Schema'
-import { Element, NormalizedData, Collection } from '../../../data/Data'
+import { Element, Collection } from '../../../data/Data'
 import { Query } from '../../../query/Query'
 import { Model } from '../../Model'
 import { Relation, Dictionary } from './Relation'
@@ -45,20 +45,10 @@ export class HasMany extends Relation {
   }
 
   /**
-   * Attach the relational key to the given data object.
+   * Attach the relational key to the given relation.
    */
-  attach(
-    ids: (string | number)[],
-    record: Element,
-    data: NormalizedData
-  ): void {
-    ids.forEach((id) => {
-      const relatedElement = data[this.related.$entity]?.[id]
-
-      if (relatedElement) {
-        relatedElement[this.foreignKey] = record[this.localKey]
-      }
-    })
+  attach(record: Element, child: Element): void {
+    child[this.foreignKey] = record[this.localKey]
   }
 
   /**

--- a/src/model/attributes/relations/HasOne.ts
+++ b/src/model/attributes/relations/HasOne.ts
@@ -1,6 +1,6 @@
 import { Schema as NormalizrSchema } from 'normalizr'
 import { Schema } from '../../../schema/Schema'
-import { Element, NormalizedData, Collection } from '../../../data/Data'
+import { Element, Collection } from '../../../data/Data'
 import { Query } from '../../../query/Query'
 import { Model } from '../../Model'
 import { Relation, Dictionary } from './Relation'
@@ -45,14 +45,10 @@ export class HasOne extends Relation {
   }
 
   /**
-   * Attach the relational key to the given data object.
+   * Attach the relational key to the given relation.
    */
-  attach(id: string | number, record: Element, data: NormalizedData): void {
-    const relatedElement = data[this.related.$entity]?.[id]
-
-    if (relatedElement) {
-      relatedElement[this.foreignKey] = record[this.localKey]
-    }
+  attach(record: Element, child: Element): void {
+    child[this.foreignKey] = record[this.localKey]
   }
 
   /**

--- a/src/model/attributes/relations/Relation.ts
+++ b/src/model/attributes/relations/Relation.ts
@@ -1,6 +1,6 @@
 import { Schema as NormalizrSchema } from 'normalizr'
 import { Schema } from '../../../schema/Schema'
-import { Element, NormalizedData, Collection } from '../../../data/Data'
+import { Element, Collection } from '../../../data/Data'
 import { Query } from '../../../query/Query'
 import { Model } from '../../Model'
 import { Attribute } from '../Attribute'
@@ -47,9 +47,9 @@ export abstract class Relation extends Attribute {
   abstract define(schema: Schema): NormalizrSchema
 
   /**
-   * Attach the relational key to the given data.
+   * Attach the relational key to the given relation.
    */
-  abstract attach(ids: any, record: Element, data: NormalizedData): void
+  abstract attach(record: Element, child: Element): void
 
   /**
    * Set the constraints for an eager loading relation.

--- a/src/schema/Schema.ts
+++ b/src/schema/Schema.ts
@@ -61,13 +61,16 @@ export class Schema {
   /**
    * The id attribute option for the normalizr entity.
    */
-  private idAttribute(model: Model, parent: Model): Normalizr.StrategyFunction<string> {
+  private idAttribute(
+    model: Model,
+    parent: Model
+  ): Normalizr.StrategyFunction<string> {
     return (record, parentRecord, key) => {
       // If the `key` is not `null`, that means this record is a nested
       // relationship of the parent model. In this case, we'll attach any
       // missing foreign keys to the record first.
       if (key !== null) {
-        (parent.$fields[key] as Relation).attach(parentRecord, record)
+        ;(parent.$fields[key] as Relation).attach(parentRecord, record)
       }
 
       return model.$getIndexId(record)


### PR DESCRIPTION
This PR refactors the way we attach foreign key to the relationship.

#### Type of PR:

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Code style update
- [ ] Build-related changes
- [ ] Test
- [ ] Documentation
- [ ] Other, please describe:

### Details

Previously, we were attaching missing foreign keys after the normalization by looping through whole normalized data. With this new approach, we'll do that inside `IdAttribute` option of Normalizr.

It makes things a bit simpler since now `Relation.attach` method. But more importantly, this makes upcoming UID attribute implementation easier. Because we can generate both UID and foreign key at the same process (inside `IdAttribute` option). This makes users to define `UID` type at the `foreign key` and still get the right result.