### PR TITLE
feat: support composite key

### DIFF
--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -32,7 +32,7 @@ export class Model {
   /**
    * The primary key for the model.
    */
-  static primaryKey: string = 'id'
+  static primaryKey: string | string[] = 'id'
 
   /**
    * The schema for the model. It contains the result of the `fields`
@@ -183,7 +183,7 @@ export class Model {
   ): HasOne {
     const model = this.newRawInstance()
 
-    localKey = localKey ?? model.$getKeyName()
+    localKey = localKey ?? model.$getLocalKey()
 
     return new HasOne(model, related.newRawInstance(), foreignKey, localKey)
   }
@@ -198,7 +198,7 @@ export class Model {
   ): BelongsTo {
     const instance = related.newRawInstance()
 
-    ownerKey = ownerKey ?? instance.$getKeyName()
+    ownerKey = ownerKey ?? instance.$getLocalKey()
 
     return new BelongsTo(this.newRawInstance(), instance, foreignKey, ownerKey)
   }
@@ -213,7 +213,7 @@ export class Model {
   ): HasMany {
     const model = this.newRawInstance()
 
-    localKey = localKey ?? model.$getKeyName()
+    localKey = localKey ?? model.$getLocalKey()
 
     return new HasMany(model, related.newRawInstance(), foreignKey, localKey)
   }
@@ -248,7 +248,7 @@ export class Model {
   /**
    * Get the primary key for this model.
    */
-  get $primaryKey(): string {
+  get $primaryKey(): string | string[] {
     return this.$self.primaryKey
   }
 
@@ -340,8 +340,52 @@ export class Model {
   /**
    * Get the primary key field name.
    */
-  $getKeyName(): string {
+  $getKeyName(): string | string[] {
     return this.$primaryKey
+  }
+
+  /**
+   * Get primary key value for the model. If the model has the composite key,
+   * it will return an array of ids.
+   */
+  $getKey(record?: Element): string | number | (string | number)[] | null {
+    record = record ?? this
+
+    if (this.$hasCompositeKey()) {
+      return this.$getCompositeKey(record)
+    }
+
+    const id = record[this.$getKeyName() as string]
+
+    return isNullish(id) ? null : id
+  }
+
+  /**
+   * Check whether the model has composite key.
+   */
+  $hasCompositeKey(): boolean {
+    return isArray(this.$getKeyName())
+  }
+
+  /**
+   * Get the composite key values for the given model as an array of ids.
+   */
+  protected $getCompositeKey(record: Element): (string | number)[] | null {
+    let ids = [] as (string | number)[] | null
+
+    ;(this.$getKeyName() as string[]).every((key) => {
+      const id = record[key]
+
+      if (isNullish(id)) {
+        ids = null
+        return false
+      }
+
+      ;(ids as (string | number)[]).push(id)
+      return true
+    })
+
+    return ids === null ? null : ids
   }
 
   /**
@@ -349,9 +393,32 @@ export class Model {
    */
   $getIndexId(record?: Element): string | null {
     const target = record ?? this
-    const id = target[this.$primaryKey]
 
-    return isNullish(id) ? null : String(id)
+    const id = this.$getKey(target)
+
+    return id === null ? null : this.$stringifyId(id)
+  }
+
+  /**
+   * Stringify the given id.
+   */
+  protected $stringifyId(id: string | number | (string | number)[]): string {
+    return isArray(id) ? JSON.stringify(id) : String(id)
+  }
+
+  /**
+   * Get the local key name for the model.
+   */
+  $getLocalKey(): string {
+    // If the model has a composite key, we can't use it as a local key for the
+    // relation. The user must provide the key name explicitly, so we'll throw
+    // an error here.
+    assert(!this.$hasCompositeKey(), [
+      'Please provide the local key for the relationship. The model with the',
+      "composite key can't infer its local key."
+    ])
+
+    return this.$getKeyName() as string
   }
 
   /**

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -4,7 +4,8 @@ import {
   isFunction,
   isEmpty,
   orderBy,
-  groupBy
+  groupBy,
+  assert
 } from '../support/Utils'
 import {
   Element,
@@ -575,6 +576,11 @@ export class Query<M extends Model = Model> {
   async destroy(id: string | number): Promise<Item<M>>
   async destroy(ids: (string | number)[]): Promise<Collection<M>>
   async destroy(ids: any): Promise<any> {
+    assert(!this.model.$hasCompositeKey(), [
+      "You can't use the `destroy` method on the model with the composite key.",
+      'Please use `delete` method instead.'
+    ])
+
     if (isArray(ids)) {
       return this.destroyMany(ids)
     }

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -577,7 +577,7 @@ export class Query<M extends Model = Model> {
   async destroy(ids: (string | number)[]): Promise<Collection<M>>
   async destroy(ids: any): Promise<any> {
     assert(!this.model.$hasCompositeKey(), [
-      "You can't use the `destroy` method on the model with the composite key.",
+      "You can't use the `destroy` method on a model with a composite key.",
       'Please use `delete` method instead.'
     ])
 
@@ -596,7 +596,7 @@ export class Query<M extends Model = Model> {
   }
 
   /**
-   * Delete records that match the query chain.
+   * Delete records resolved by the query chain.
    */
   async delete(): Promise<Collection<M>> {
     const models = this.get()

--- a/src/schema/Schema.ts
+++ b/src/schema/Schema.ts
@@ -1,5 +1,5 @@
 import { schema as Normalizr, Schema as NormalizrSchema } from 'normalizr'
-import { isNullish, assert } from '../support/Utils'
+import { isNullish, isArray, assert } from '../support/Utils'
 import { Uid } from '../model/attributes/types/Uid'
 import { Relation } from '../model/attributes/relations/Relation'
 import { Model } from '../model/Model'
@@ -115,7 +115,7 @@ export class Schema {
       // index id.
       const indexId = model.$getIndexId(record)
 
-      assert(!isNullish(indexId), [
+      assert(indexId !== null, [
         'The record is missing the primary key. If you want to persist record',
         'without the primary key, please defined the primary key field as',
         '`uid` field.'
@@ -129,14 +129,20 @@ export class Schema {
    * Get all primary keys defined by the Uid attribute for the given model.
    */
   private getUidPrimaryKeyPairs(model: Model): Record<string, Uid> {
+    const key = model.$getKeyName()
+    const keys = isArray(key) ? key : [key]
+
     const attributes = {} as Record<string, Uid>
 
-    const key = model.$getKeyName()
-    const attr = model.$fields[key]
+    keys.forEach((k) => {
+      const attr = model.$fields[k]
 
-    if (attr instanceof Uid) {
-      attributes[key] = attr
-    }
+      if (attr instanceof Uid) {
+        attributes[k] = attr
+      }
+
+      model.$fields[k]
+    })
 
     return attributes
   }

--- a/test/feature/repository/deletes_destroy_composite_key.spec.ts
+++ b/test/feature/repository/deletes_destroy_composite_key.spec.ts
@@ -1,0 +1,34 @@
+import { createStore, fillState } from 'test/Helpers'
+import { Model, Attr, Str } from '@/index'
+
+describe('feature/repository/deletes_destroy_composite_key', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static primaryKey = ['idA', 'idB']
+
+    @Attr() idA!: any
+    @Attr() idB!: any
+    @Str('') name!: string
+  }
+
+  it('throws if the model has composite key', async () => {
+    expect.assertions(1)
+
+    const store = createStore()
+
+    fillState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' },
+        2: { id: 2, name: 'Jane Doe' },
+        3: { id: 3, name: 'Johnny Doe' }
+      }
+    })
+
+    try {
+      await store.$repo(User).destroy(2)
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error)
+    }
+  })
+})

--- a/test/feature/repository/inserts_fresh_composite_key.spec.ts
+++ b/test/feature/repository/inserts_fresh_composite_key.spec.ts
@@ -1,0 +1,42 @@
+import { createStore, assertState } from 'test/Helpers'
+import { Model, Attr, Str } from '@/index'
+
+describe('feature/repository/inserts_fresh_composite_key', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static primaryKey = ['idA', 'idB']
+
+    @Attr() idA!: any
+    @Attr() idB!: any
+    @Str('') name!: string
+  }
+
+  it('inserts records with the composite key', async () => {
+    const store = createStore()
+
+    await store.$repo(User).fresh([
+      { idA: 1, idB: 2, name: 'John Doe' },
+      { idA: 2, idB: 1, name: 'Jane Doe' }
+    ])
+
+    assertState(store, {
+      users: {
+        '[1,2]': { idA: 1, idB: 2, name: 'John Doe' },
+        '[2,1]': { idA: 2, idB: 1, name: 'Jane Doe' }
+      }
+    })
+  })
+
+  it('throws if the one of the composite key is missing', async () => {
+    expect.assertions(1)
+
+    const store = createStore()
+
+    try {
+      await store.$repo(User).insert({ idA: 1, name: 'John Doe' })
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error)
+    }
+  })
+})

--- a/test/feature/repository/inserts_insert_composite_key.spec.ts
+++ b/test/feature/repository/inserts_insert_composite_key.spec.ts
@@ -1,0 +1,42 @@
+import { createStore, assertState } from 'test/Helpers'
+import { Model, Attr, Str } from '@/index'
+
+describe('feature/repository/inserts_insert_composite_key', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static primaryKey = ['idA', 'idB']
+
+    @Attr() idA!: any
+    @Attr() idB!: any
+    @Str('') name!: string
+  }
+
+  it('inserts records with the composite key', async () => {
+    const store = createStore()
+
+    await store.$repo(User).insert([
+      { idA: 1, idB: 2, name: 'John Doe' },
+      { idA: 2, idB: 1, name: 'Jane Doe' }
+    ])
+
+    assertState(store, {
+      users: {
+        '[1,2]': { idA: 1, idB: 2, name: 'John Doe' },
+        '[2,1]': { idA: 2, idB: 1, name: 'Jane Doe' }
+      }
+    })
+  })
+
+  it('throws if the one of the composite key is missing', async () => {
+    expect.assertions(1)
+
+    const store = createStore()
+
+    try {
+      await store.$repo(User).insert({ idA: 1, name: 'John Doe' })
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error)
+    }
+  })
+})

--- a/test/feature/repository/updates_update_composite_key.spec.ts
+++ b/test/feature/repository/updates_update_composite_key.spec.ts
@@ -1,0 +1,54 @@
+import { createStore, fillState, assertState } from 'test/Helpers'
+import { Model, Attr, Str, Num } from '@/index'
+
+describe('feature/repository/updates_update_composite_key', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static primaryKey = ['idA', 'idB']
+
+    @Attr() idA!: any
+    @Attr() idB!: any
+    @Str('') name!: string
+    @Num(0) age!: number
+  }
+
+  it('update records with composite key', async () => {
+    const store = createStore()
+
+    fillState(store, {
+      users: {
+        '[1,2]': { idA: 1, idB: 2, name: 'John Doe', age: 40 },
+        '[2,1]': { idA: 2, idB: 1, name: 'Jane Doe', age: 30 }
+      }
+    })
+
+    await store.$repo(User).update({ idA: 2, idB: 1, age: 50 })
+
+    assertState(store, {
+      users: {
+        '[1,2]': { idA: 1, idB: 2, name: 'John Doe', age: 40 },
+        '[2,1]': { idA: 2, idB: 1, name: 'Jane Doe', age: 50 }
+      }
+    })
+  })
+
+  it('throws if the one of the composite key is missing', async () => {
+    expect.assertions(1)
+
+    const store = createStore()
+
+    fillState(store, {
+      users: {
+        '[1,2]': { idA: 1, idB: 2, name: 'John Doe', age: 40 },
+        '[2,1]': { idA: 2, idB: 1, name: 'Jane Doe', age: 30 }
+      }
+    })
+
+    try {
+      await store.$repo(User).update({ idA: 2, age: 50 })
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error)
+    }
+  })
+})

--- a/test/unit/model/Model_Keys.spec.ts
+++ b/test/unit/model/Model_Keys.spec.ts
@@ -1,0 +1,68 @@
+import { Attr } from '@/model/decorators/attributes/types/Attr'
+import { Model } from '@/model/Model'
+
+describe('unit/model/Model_Keys', () => {
+  beforeEach(() => {
+    Model.clearRegistries()
+  })
+
+  it('can get primary key value of the model', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Attr() id!: any
+    }
+
+    const userA = new User({ id: 1 })
+    expect(userA.$getKey()).toBe(1)
+
+    const userB = new User()
+    expect(userB.$getKey()).toBe(null)
+  })
+
+  it('can get primary key value of the given record', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Attr() id!: any
+    }
+
+    const user = new User()
+
+    expect(user.$getKey({ id: 1 })).toBe(1)
+    expect(user.$getKey({})).toBe(null)
+  })
+
+  it('can get composite primary key value of the model', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static primaryKey = ['idA', 'idB']
+
+      @Attr() idA!: any
+      @Attr() idB!: any
+    }
+
+    const userA = new User({ idA: 1, idB: 2 })
+    expect(userA.$getKey()).toEqual([1, 2])
+
+    const userB = new User({ idA: 1 })
+    expect(userB.$getKey()).toEqual(null)
+  })
+
+  it('can get composite primary key value of the given record', () => {
+    class User extends Model {
+      static entity = 'users'
+
+      static primaryKey = ['idA', 'idB']
+
+      @Attr() idA!: any
+      @Attr() idB!: any
+    }
+
+    const user = new User()
+
+    expect(user.$getKey({ idA: 1, idB: 2 })).toEqual([1, 2])
+    expect(user.$getKey({ idA: 1 })).toEqual(null)
+  })
+})


### PR DESCRIPTION
This PR adds composite key support.

#### Type of PR:

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Code style update
- [ ] Build-related changes
- [ ] Test
- [ ] Documentation
- [ ] Other, please describe:

### Details

The composite key works as same as current Vuex ORM. It will generate index id looks as stringified array of ids (e.g. `'[1,2]'`).

#### Note on `destroy` method.

Currently `destroy` method will throw immediately if the model has composite key because it doesn't make sense yet. Not sure if we would want to support composite key on such methods since users could do `repo.where('idA', 1).where('idB', 2).delete()`.

At least for now, I think we can stay not supporting composite key in the methods that requires a single primary key to be passed in. We could come up with better idea in the future.