### PR TITLE
feat: Add support for multiple databases

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -1,5 +1,6 @@
 import { Store } from 'vuex'
 import { Element, Elements } from '../data/Data'
+import { Database } from '@/database/Database'
 
 export interface ConnectionNamespace {
   connection: string
@@ -25,9 +26,9 @@ export class Connection {
   /**
    * Create a new connection instance.
    */
-  constructor(store: Store<any>, entity: string) {
-    this.store = store
-    this.connection = store.$database.connection
+  constructor(database: Database, entity: string) {
+    this.store = database.store
+    this.connection = database.connection
     this.entity = entity
   }
 

--- a/src/database/Database.ts
+++ b/src/database/Database.ts
@@ -89,7 +89,7 @@ export class Database {
 
       if (attr instanceof Relation) {
         attr.getRelateds().forEach((m) => {
-          this.register(m.$setStore(this.store))
+          this.register(m.$setDatabase(this))
         })
       }
     }

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -1,14 +1,14 @@
 import { normalize, schema as Normalizr } from 'normalizr'
-import { Store } from 'vuex'
 import { isArray, isEmpty } from '../support/Utils'
 import { Element, NormalizedData } from '../data/Data'
 import { Model } from '../model/Model'
+import { Database } from '@/database/Database'
 
 export class Interpreter<M extends Model> {
   /**
-   * The store instance.
+   * The database instance.
    */
-  store: Store<any>
+  database: Database
 
   /**
    * The model object.
@@ -18,8 +18,8 @@ export class Interpreter<M extends Model> {
   /**
    * Create a new Interpreter instance.
    */
-  constructor(store: Store<any>, model: M) {
-    this.store = store
+  constructor(database: Database, model: M) {
+    this.database = database
     this.model = model
   }
 
@@ -43,6 +43,6 @@ export class Interpreter<M extends Model> {
    * Get the schema from the database.
    */
   private getSchema(): Normalizr.Entity {
-    return this.store.$database.getSchema(this.model.$entity())
+    return this.database.getSchema(this.model.$entity())
   }
 }

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -1,4 +1,3 @@
-import { Store } from 'vuex'
 import { isNullish, isArray, assert } from '../support/Utils'
 import { Element, Item, Collection } from '../data/Data'
 import { Query } from '../query/Query'
@@ -14,6 +13,7 @@ import { HasOne } from './attributes/relations/HasOne'
 import { BelongsTo } from './attributes/relations/BelongsTo'
 import { HasMany } from './attributes/relations/HasMany'
 import { HasManyBy } from './attributes/relations/HasManyBy'
+import { Database } from '@/database/Database'
 
 export type ModelFields = Record<string, Attribute>
 export type ModelSchemas = Record<string, ModelFields>
@@ -55,10 +55,10 @@ export class Model {
   protected static booted: Record<string, boolean> = {}
 
   /**
-   * The store instance.
+   * The database instance.
    */
   @NonEnumerable
-  protected _store!: Store<any>
+  protected _database!: Database
 
   /**
    * Create a new model instance.
@@ -243,23 +243,23 @@ export class Model {
   }
 
   /**
-   * Get the store instance.
+   * Get the database instance.
    */
-  $store(): Store<any> {
-    assert(this._store !== undefined, [
+  $database(): Database {
+    assert(this._database !== undefined, [
       'A Vuex Store instance is not injected into the model instance.',
       'You might be trying to instantiate the model directly. Please use',
       '`repository.make` method to create a new model instance.'
     ])
 
-    return this._store
+    return this._database
   }
 
   /**
-   * Set the store instance.
+   * Set the database instance.
    */
-  $setStore(store: Store<any>): this {
-    this._store = store
+  $setDatabase(database: Database): this {
+    this._database = database
 
     return this
   }
@@ -294,7 +294,7 @@ export class Model {
     const self = this.$self()
     const model = new self(attributes, options) as this
 
-    model.$setStore(this.$store())
+    model.$setDatabase(this.$database())
 
     return model
   }
@@ -303,7 +303,7 @@ export class Model {
    * Create a new query instance.
    */
   $query(): Query<this> {
-    return new Query(this.$store(), this)
+    return new Query(this.$database(), this)
   }
 
   /**

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -1,4 +1,3 @@
-import { Store } from 'vuex'
 import {
   isArray,
   isFunction,
@@ -30,6 +29,7 @@ import {
   EagerLoadConstraint,
   PersistMethod
 } from './Options'
+import { Database } from '@/database/Database'
 
 export interface CollectionPromises {
   indexes: string[]
@@ -38,9 +38,9 @@ export interface CollectionPromises {
 
 export class Query<M extends Model = Model> {
   /**
-   * The store instance.
+   * The database instance.
    */
-  protected store: Store<any>
+  database: Database
 
   /**
    * The model object.
@@ -85,26 +85,29 @@ export class Query<M extends Model = Model> {
   /**
    * Create a new query instance.
    */
-  constructor(store: Store<any>, model: M) {
-    this.store = store
+  constructor(database: Database, model: M) {
+    this.database = database
     this.model = model
 
-    this.interpreter = new Interpreter(store, model)
-    this.connection = new Connection(store, model.$entity())
+    this.interpreter = new Interpreter(database, model)
+    this.connection = new Connection(database, model.$entity())
   }
 
   /**
    * Create a new query instance for the given model.
    */
   protected newQuery(model: string): Query<Model> {
-    return new Query(this.store, this.store.$database.getModel(model))
+    return new Query(this.database, this.database.getModel(model))
   }
 
   /**
    * Create a new query instance from the given relation.
    */
   protected newQueryForRelation(relation: Relation): Query<Model> {
-    return new Query(this.store, relation.getRelated().$setStore(this.store))
+    return new Query(
+      this.database,
+      relation.getRelated().$setDatabase(this.database)
+    )
   }
 
   /**

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -1,4 +1,3 @@
-import { Store } from 'vuex'
 import { Constructor } from '../types'
 import { assert } from '../support/Utils'
 import { Element, Item, Collection, Collections } from '../data/Data'
@@ -12,6 +11,7 @@ import {
   OrderBy,
   EagerLoadConstraint
 } from '../query/Options'
+import { Database } from '@/database/Database'
 
 export class Repository<M extends Model = Model> {
   /**
@@ -22,9 +22,9 @@ export class Repository<M extends Model = Model> {
   static _isRepository: boolean = true
 
   /**
-   * The store instance.
+   * The database instance.
    */
-  protected store: Store<any>
+  database: Database
 
   /**
    * The model instance.
@@ -39,8 +39,8 @@ export class Repository<M extends Model = Model> {
   /**
    * Create a new Repository instance.
    */
-  constructor(store: Store<any>) {
-    this.store = store
+  constructor(database: Database) {
+    this.database = database
   }
 
   /**
@@ -49,7 +49,7 @@ export class Repository<M extends Model = Model> {
   initialize(model?: ModelConstructor<M>): this {
     // If there's a model passed in, just use that and return immediately.
     if (model) {
-      this.model = model.newRawInstance().$setStore(this.store)
+      this.model = model.newRawInstance().$setDatabase(this.database)
 
       return this
     }
@@ -59,7 +59,7 @@ export class Repository<M extends Model = Model> {
     // In this case, we'll check if the user has set model to the `use`
     // property and instantiate that.
     if (this.use) {
-      this.model = (this.use.newRawInstance() as M).$setStore(this.store)
+      this.model = (this.use.newRawInstance() as M).$setDatabase(this.database)
 
       return this
     }
@@ -89,14 +89,14 @@ export class Repository<M extends Model = Model> {
   repo<M extends Model>(model: Constructor<M>): Repository<M>
   repo<R extends Repository<any>>(repository: Constructor<R>): R
   repo(modelOrRepository: any): any {
-    return this.store.$repo(modelOrRepository)
+    return this.database.store.$repo(modelOrRepository)
   }
 
   /**
    * Create a new Query instance.
    */
   query(): Query<M> {
-    return new Query(this.store, this.getModel())
+    return new Query(this.database, this.getModel())
   }
 
   /**

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -52,6 +52,8 @@ function createDatabase(
     .setConnection(options.namespace)
 
   store.$database = database
+  if (!store.$databases) store.$databases = {}
+  store.$databases[database.connection] = database
 }
 
 /**
@@ -76,13 +78,25 @@ function startDatabase(store: Store<any>): void {
  * Mixin repo function to the store.
  */
 function mixinRepoFunction(store: Store<any>): void {
-  store.$repo = function (modelOrRepository: any): any {
+  store.$repo = function (modelOrRepository: any, connection?: string): any {
+    let database: Database
+    if (connection) {
+      if (!(connection in store.$databases)) {
+        database = new Database().setStore(store).setConnection(connection)
+        store.$databases[connection] = database
+        database.start()
+      } else {
+        database = store.$databases[connection]
+      }
+    } else {
+      database = store.$database
+    }
     const repository = modelOrRepository._isRepository
       ? new modelOrRepository(this).initialize()
-      : new Repository(this).initialize(modelOrRepository)
+      : new Repository(database).initialize(modelOrRepository)
 
     try {
-      store.$database.register(repository.getModel())
+      database.register(repository.getModel())
     } catch (e) {
     } finally {
       return repository

--- a/src/types/vuex.ts
+++ b/src/types/vuex.ts
@@ -6,14 +6,25 @@ import { Repository } from '../repository/Repository'
 declare module 'vuex/types/index' {
   interface Store<S> {
     /**
-     * The database instance.
+     * The default database instance.
      */
     $database: Database
 
     /**
+     * Mapping of databases keyed on connection
+     */
+    $databases: { [key: string]: Database }
+
+    /**
      * Get a new Repository instance for the given model.
      */
-    $repo<M extends Model>(model: Constructor<M>): Repository<M>
-    $repo<R extends Repository<any>>(repository: Constructor<R>): R
+    $repo<M extends Model>(
+      model: Constructor<M>,
+      connection?: string
+    ): Repository<M>
+    $repo<R extends Repository<any>>(
+      repository: Constructor<R>,
+      connection?: string
+    ): R
   }
 }

--- a/src/types/vuex.ts
+++ b/src/types/vuex.ts
@@ -22,7 +22,8 @@ declare module 'vuex/types/index' {
       model: Constructor<M>,
       connection?: string
     ): Repository<M>
-    $repo<R extends Repository<any>>(
+
+    $repo<R extends Repository>(
       repository: Constructor<R>,
       connection?: string
     ): R

--- a/test/unit/model/Model.spec.ts
+++ b/test/unit/model/Model.spec.ts
@@ -6,6 +6,6 @@ describe('unit/model/Model', () => {
   }
 
   it('throws when accessing the store but it is not injected', () => {
-    expect(() => new User().$store()).toThrow()
+    expect(() => new User().$database()).toThrow()
   })
 })

--- a/test/unit/repository/Repository.spec.ts
+++ b/test/unit/repository/Repository.spec.ts
@@ -36,6 +36,10 @@ describe('unit/repository/Repository', () => {
     expect(user.$database()).toBe(store.$databases[connection])
     expect(user.$database().started).toBe(true)
     assertModel(user, { id: null, name: 'John Doe' })
+
+    // Fetches the same atabase on 2nd call.
+    const user2 = store.$repo(User, connection).make()
+    assertModel(user2, { id: null, name: 'John Doe' })
   })
 
   it('creates a new model instance with default values', () => {

--- a/test/unit/repository/Repository.spec.ts
+++ b/test/unit/repository/Repository.spec.ts
@@ -22,7 +22,19 @@ describe('unit/repository/Repository', () => {
     const user = store.$repo(User).make()
 
     expect(user).toBeInstanceOf(User)
-    expect(user.$store()).toBe(store)
+    expect(user.$database()).toBe(store.$database)
+    assertModel(user, { id: null, name: 'John Doe' })
+  })
+
+  it('creates a new model instance in a new database', () => {
+    const store = createStore()
+
+    const connection = 'test_namespace'
+    const user = store.$repo(User, connection).make()
+
+    expect(user).toBeInstanceOf(User)
+    expect(user.$database()).toBe(store.$databases[connection])
+    expect(user.$database().started).toBe(true)
     assertModel(user, { id: null, name: 'John Doe' })
   })
 
@@ -35,7 +47,7 @@ describe('unit/repository/Repository', () => {
     })
 
     expect(user).toBeInstanceOf(User)
-    expect(user.$store()).toBe(store)
+    expect(user.$database()).toBe(store.$database)
     assertModel(user, { id: 1, name: 'Jane Doe' })
   })
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- Please describe a summary of this PR. -->

This is from a discussion with @kiaking and @cuebit on the Slack.

#### Type of PR:

- [ ] Bugfix
- [x] Feature
- [x] Refactor
- [ ] Code style update
- [ ] Build-related changes
- [ ] Test
- [ ] Documentation
- [ ] Other, please describe:

#### Breaking changes:

- [ ] No
- [x] Yes

### Details
This adds support for multiple namespaces.
Repositories or Models can be registered and accessed under multiple namespaces via `store.$repo(Model, 'namepace')`.
Some classes now retain the database rather than the store.

<!-- Please describe the details of the PR. -->
