### PR TITLE
fix(repository): implement missing `add` & `replace` methods

### DIFF
--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -417,12 +417,18 @@ export class Model {
   /**
    * Get the index id of this model or for a given record.
    */
-  $getIndexId(record?: Element): string | null {
+  $getIndexId(record?: Element): string {
     const target = record ?? this
 
     const id = this.$getKey(target)
 
-    return id === null ? null : this.$stringifyId(id)
+    assert(id !== null, [
+      'The record is missing the primary key. If you want to persist record',
+      'without the primary key, please define the primary key field with the',
+      '`uid` attribute.'
+    ])
+
+    return this.$stringifyId(id)
   }
 
   /**

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -450,7 +450,7 @@ export class Query<M extends Model = Model> {
     const recordsArray = isArray(records) ? records : [records]
 
     const models = recordsArray.reduce<Collection<M>>((collection, record) => {
-      const model = this.pick(this.model.$getIndexId(record)!)
+      const model = this.pick(this.model.$getIndexId(record))
 
       model && collection.push(model.$fill(record))
 
@@ -615,7 +615,7 @@ export class Query<M extends Model = Model> {
    * Get an array of ids from the given collection.
    */
   protected getIndexIdsFromCollection(models: Collection<M>): string[] {
-    return models.map((model) => model.$getIndexId()!)
+    return models.map((model) => model.$getIndexId())
   }
 
   /**
@@ -637,7 +637,7 @@ export class Query<M extends Model = Model> {
     const modelArray = isArray(models) ? models : [models]
 
     return modelArray.reduce<Elements>((records, model) => {
-      records[model.$getIndexId()!] = model.$getAttributes()
+      records[model.$getIndexId()] = model.$getAttributes()
       return records
     }, {})
   }

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -175,10 +175,19 @@ export class Repository<M extends Model = Model> {
   }
 
   /**
-   * Insert the given record to the store.
+   * Insert the given records to the store.
    */
   insert(records: Element | Element[]): Promise<Collections> {
     return this.query().insert(records)
+  }
+
+  /**
+   * Insert the given records to the store without normalization.
+   */
+  add(records: Element[]): Promise<Collection<M>>
+  add(record: Element): Promise<M>
+  add(records: any): Promise<any> {
+    return this.query().add(records)
   }
 
   /**
@@ -186,6 +195,16 @@ export class Repository<M extends Model = Model> {
    */
   fresh(records: Element | Element[]): Promise<Collections> {
     return this.query().fresh(records)
+  }
+
+  /**
+   * Insert the given records to the store by replacing any existing records
+   * without normalization.
+   */
+  replace(records: Element[]): Promise<Collection<M>>
+  replace(record: Element): Promise<M>
+  replace(records: any): Promise<any> {
+    return this.query().replace(records)
   }
 
   /**

--- a/src/schema/Schema.ts
+++ b/src/schema/Schema.ts
@@ -1,5 +1,5 @@
 import { schema as Normalizr, Schema as NormalizrSchema } from 'normalizr'
-import { isNullish, isArray, assert } from '../support/Utils'
+import { isNullish, isArray } from '../support/Utils'
 import { Uid } from '../model/attributes/types/Uid'
 import { Relation } from '../model/attributes/relations/Relation'
 import { Model } from '../model/Model'
@@ -111,20 +111,8 @@ export class Schema {
         }
       }
 
-      // Finally, we'll check if the model has a valid index id. If not, that
-      // means users have passed in the record without a primary key, and the
-      // primary key field is not defined as uid field. In this case, we'll
-      // throw an error. Otherwise, everything is fine, so let's return the
-      // index id.
-      const indexId = model.$getIndexId(record)
-
-      assert(indexId !== null, [
-        'The record is missing the primary key. If you want to persist record',
-        'without the primary key, please defined the primary key field as',
-        '`uid` field.'
-      ])
-
-      return indexId
+      // Finally, obtain the index id and return.
+      return model.$getIndexId(record)
     }
   }
 

--- a/test/feature/repository/inserts_add.spec.ts
+++ b/test/feature/repository/inserts_add.spec.ts
@@ -1,0 +1,39 @@
+import { createStore, assertState } from 'test/Helpers'
+import { Model, Attr, Str } from '@/index'
+
+describe('feature/repository/inserts_add', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    @Attr() id!: any
+    @Str('') name!: string
+  }
+
+  it('inserts a record to the store', async () => {
+    const store = createStore()
+
+    await store.$repo(User).add({ id: 1, name: 'John Doe' })
+
+    assertState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' }
+      }
+    })
+  })
+
+  it('inserts multiple records to the store', async () => {
+    const store = createStore()
+
+    await store.$repo(User).add([
+      { id: 1, name: 'John Doe' },
+      { id: 2, name: 'Jane Doe' }
+    ])
+
+    assertState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' },
+        2: { id: 2, name: 'Jane Doe' }
+      }
+    })
+  })
+})

--- a/test/feature/repository/inserts_add_composite_key.spec.ts
+++ b/test/feature/repository/inserts_add_composite_key.spec.ts
@@ -27,4 +27,16 @@ describe('feature/repository/inserts_add_composite_key', () => {
       }
     })
   })
+
+  it('throws if composite key is incomplete', async () => {
+    expect.assertions(1)
+
+    const store = createStore()
+
+    try {
+      await store.$repo(User).add({ idA: 1, name: 'John Doe' })
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error)
+    }
+  })
 })

--- a/test/feature/repository/inserts_add_composite_key.spec.ts
+++ b/test/feature/repository/inserts_add_composite_key.spec.ts
@@ -1,0 +1,30 @@
+import { createStore, assertState } from 'test/Helpers'
+import { Model, Attr, Str } from '@/index'
+
+describe('feature/repository/inserts_add_composite_key', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static primaryKey = ['idA', 'idB']
+
+    @Attr() idA!: any
+    @Attr() idB!: any
+    @Str('') name!: string
+  }
+
+  it('inserts records with a composite key', async () => {
+    const store = createStore()
+
+    await store.$repo(User).add([
+      { idA: 1, idB: 2, name: 'John Doe' },
+      { idA: 2, idB: 1, name: 'Jane Doe' }
+    ])
+
+    assertState(store, {
+      users: {
+        '[1,2]': { idA: 1, idB: 2, name: 'John Doe' },
+        '[2,1]': { idA: 2, idB: 1, name: 'Jane Doe' }
+      }
+    })
+  })
+})

--- a/test/feature/repository/inserts_add_uid.spec.ts
+++ b/test/feature/repository/inserts_add_uid.spec.ts
@@ -1,0 +1,26 @@
+import { createStore, assertState, mockUid } from 'test/Helpers'
+import { Model, Uid, Str } from '@/index'
+
+describe('feature/uid/inserts_add_uid', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    @Uid() id!: string | null
+    @Str('') name!: string
+  }
+
+  it('generates a unique id for a `uid` attribute', async () => {
+    mockUid(['uid1', 'uid2'])
+
+    const store = createStore()
+
+    await store.$repo(User).add([{ name: 'John Doe' }, { name: 'Jane Doe' }])
+
+    assertState(store, {
+      users: {
+        uid1: { id: 'uid1', name: 'John Doe' },
+        uid2: { id: 'uid2', name: 'Jane Doe' }
+      }
+    })
+  })
+})

--- a/test/feature/repository/inserts_replace.spec.ts
+++ b/test/feature/repository/inserts_replace.spec.ts
@@ -37,8 +37,6 @@ describe('feature/repository/inserts_replace', () => {
     })
   })
 
-
-
   it('replaces existing records', async () => {
     const store = createStore()
 

--- a/test/feature/repository/inserts_replace.spec.ts
+++ b/test/feature/repository/inserts_replace.spec.ts
@@ -1,0 +1,64 @@
+import { createStore, fillState, assertState } from 'test/Helpers'
+import { Model, Attr, Str } from '@/index'
+
+describe('feature/repository/inserts_replace', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    @Attr() id!: any
+    @Str('') name!: string
+  }
+
+  it('replaces a record in the store', async () => {
+    const store = createStore()
+
+    await store.$repo(User).replace({ id: 1, name: 'John Doe' })
+
+    assertState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' }
+      }
+    })
+  })
+
+  it('replaces multiple records in the store', async () => {
+    const store = createStore()
+
+    await store.$repo(User).replace([
+      { id: 1, name: 'John Doe' },
+      { id: 2, name: 'Jane Doe' }
+    ])
+
+    assertState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' },
+        2: { id: 2, name: 'Jane Doe' }
+      }
+    })
+  })
+
+
+
+  it('replaces existing records', async () => {
+    const store = createStore()
+
+    fillState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' },
+        2: { id: 2, name: 'Jane Doe' }
+      }
+    })
+
+    await store.$repo(User).replace([
+      { id: 3, name: 'Johnny Doe' },
+      { id: 4, name: 'David Doe' }
+    ])
+
+    assertState(store, {
+      users: {
+        3: { id: 3, name: 'Johnny Doe' },
+        4: { id: 4, name: 'David Doe' }
+      }
+    })
+  })
+})

--- a/test/feature/repository/inserts_replace.spec.ts
+++ b/test/feature/repository/inserts_replace.spec.ts
@@ -9,7 +9,7 @@ describe('feature/repository/inserts_replace', () => {
     @Str('') name!: string
   }
 
-  it('replaces a record in the store', async () => {
+  it('inserts a record in the store', async () => {
     const store = createStore()
 
     await store.$repo(User).replace({ id: 1, name: 'John Doe' })
@@ -21,7 +21,7 @@ describe('feature/repository/inserts_replace', () => {
     })
   })
 
-  it('replaces multiple records in the store', async () => {
+  it('inserts multiple records in the store', async () => {
     const store = createStore()
 
     await store.$repo(User).replace([

--- a/test/feature/repository/inserts_replace_composite_key.spec.ts
+++ b/test/feature/repository/inserts_replace_composite_key.spec.ts
@@ -27,4 +27,16 @@ describe('feature/repository/inserts_replace_composite_key', () => {
       }
     })
   })
+
+  it('throws if composite key is incomplete', async () => {
+    expect.assertions(1)
+
+    const store = createStore()
+
+    try {
+      await store.$repo(User).replace({ idA: 1, name: 'John Doe' })
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error)
+    }
+  })
 })

--- a/test/feature/repository/inserts_replace_composite_key.spec.ts
+++ b/test/feature/repository/inserts_replace_composite_key.spec.ts
@@ -1,0 +1,30 @@
+import { createStore, assertState } from 'test/Helpers'
+import { Model, Attr, Str } from '@/index'
+
+describe('feature/repository/inserts_replace_composite_key', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    static primaryKey = ['idA', 'idB']
+
+    @Attr() idA!: any
+    @Attr() idB!: any
+    @Str('') name!: string
+  }
+
+  it('inserts records with a composite key', async () => {
+    const store = createStore()
+
+    await store.$repo(User).replace([
+      { idA: 1, idB: 2, name: 'John Doe' },
+      { idA: 2, idB: 1, name: 'Jane Doe' }
+    ])
+
+    assertState(store, {
+      users: {
+        '[1,2]': { idA: 1, idB: 2, name: 'John Doe' },
+        '[2,1]': { idA: 2, idB: 1, name: 'Jane Doe' }
+      }
+    })
+  })
+})

--- a/test/feature/repository/inserts_replace_uid.spec.ts
+++ b/test/feature/repository/inserts_replace_uid.spec.ts
@@ -1,0 +1,26 @@
+import { createStore, assertState, mockUid } from 'test/Helpers'
+import { Model, Uid, Str } from '@/index'
+
+describe('feature/uid/inserts_replace_uid', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    @Uid() id!: string | null
+    @Str('') name!: string
+  }
+
+  it('generates a unique id for a `uid` attribute', async () => {
+    mockUid(['uid1', 'uid2'])
+
+    const store = createStore()
+
+    await store.$repo(User).replace([{ name: 'John Doe' }, { name: 'Jane Doe' }])
+
+    assertState(store, {
+      users: {
+        uid1: { id: 'uid1', name: 'John Doe' },
+        uid2: { id: 'uid2', name: 'Jane Doe' }
+      }
+    })
+  })
+})

--- a/test/feature/repository/inserts_replace_uid.spec.ts
+++ b/test/feature/repository/inserts_replace_uid.spec.ts
@@ -14,7 +14,9 @@ describe('feature/uid/inserts_replace_uid', () => {
 
     const store = createStore()
 
-    await store.$repo(User).replace([{ name: 'John Doe' }, { name: 'Jane Doe' }])
+    await store
+      .$repo(User)
+      .replace([{ name: 'John Doe' }, { name: 'Jane Doe' }])
 
     assertState(store, {
       users: {


### PR DESCRIPTION
This PR implements the repository's `add` and `replace` methods that happen to be missing but are documented.

#### Type of PR:

- [x] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Code style update
- [ ] Build-related changes
- [x] Test
- [ ] Documentation
- [ ] Other, please describe:

#### Breaking changes:

- [x] No
- [ ] Yes