### PR TITLE
feat: add `save` and `revive` method

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,14 +21,10 @@ function createEntries() {
 function createEntry(config) {
   const c = {
     input: config.input,
-    external: ['vue'],
     plugins: [],
     output: {
       file: config.file,
-      format: config.format,
-      globals: {
-        vue: 'Vue'
-      }
+      format: config.format
     },
     onwarn: (msg, warn) => {
       if (!/Circular/.test(msg)) {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,6 +21,7 @@ function createEntries() {
 function createEntry(config) {
   const c = {
     input: config.input,
+    external: ['vue'],
     plugins: [],
     output: {
       file: config.file,

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -66,16 +66,9 @@ export class Connection<M extends Model> {
         const record = records[id]
         const existing = data[id]
 
-        // TODO: Refactor this with more efficient methods.
         existing
-          ? Vue.set(
-              data,
-              id,
-              this.model
-                .$newInstance({ ...existing, ...record })
-                .$getAttributes()
-            )
-          : Vue.set(data, id, this.model.$newInstance(record).$getAttributes())
+          ? Object.assign(existing, this.model.$sanitize(record))
+          : Vue.set(data, id, this.model.$sanitizeAndFill(record))
       }
     })
   }

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import { Store } from 'vuex'
 import { Element, Elements } from '../data/Data'
 import { Database } from '../database/Database'
@@ -61,16 +60,20 @@ export class Connection<M extends Model> {
    * Commit `save` mutation to the store.
    */
   save(records: Elements): void {
-    this.commit('save', (data: Elements) => {
-      for (const id in records) {
-        const record = records[id]
-        const existing = data[id]
+    const newRecords = {} as Elements
 
-        existing
-          ? Object.assign(existing, this.model.$sanitize(record))
-          : Vue.set(data, id, this.model.$sanitizeAndFill(record))
-      }
-    })
+    const data = this.get()
+
+    for (const id in records) {
+      const record = records[id]
+      const existing = data[id]
+
+      newRecords[id] = existing
+        ? Object.assign({}, existing, this.model.$sanitize(record))
+        : this.model.$sanitizeAndFill(record)
+    }
+
+    this.commit('save', newRecords)
   }
 
   /**

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -38,7 +38,9 @@ export class Connection<M extends Model> {
    * Commit a namespaced store mutation.
    */
   private commit(name: string, payload?: any): void {
-    this.store.commit(`${this.connection}/${this.model.$entity()}/${name}`, payload)
+    const type = `${this.connection}/${this.model.$entity()}/${name}`
+
+    this.store.commit(type, payload)
   }
 
   /**
@@ -66,7 +68,13 @@ export class Connection<M extends Model> {
 
         // TODO: Refactor this with more efficient methods.
         existing
-          ? Vue.set(data, id, this.model.$newInstance({ ...existing, ...record }).$getAttributes())
+          ? Vue.set(
+              data,
+              id,
+              this.model
+                .$newInstance({ ...existing, ...record })
+                .$getAttributes()
+            )
           : Vue.set(data, id, this.model.$newInstance(record).$getAttributes())
       }
     })

--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -1,4 +1,3 @@
-import { NormalizedSchema as BaseNormalizedSchema } from 'normalizr'
 import { Model } from '../model/Model'
 
 export type Element = Record<string, any>
@@ -6,8 +5,6 @@ export type Element = Record<string, any>
 export interface Elements {
   [id: string]: Element
 }
-
-export type NormalizedSchema<R> = BaseNormalizedSchema<Elements, R>
 
 export interface NormalizedData {
   [entity: string]: Elements

--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -1,3 +1,4 @@
+import { NormalizedSchema as BaseNormalizedSchema } from 'normalizr'
 import { Model } from '../model/Model'
 
 export type Element = Record<string, any>
@@ -5,6 +6,8 @@ export type Element = Record<string, any>
 export interface Elements {
   [id: string]: Element
 }
+
+export type NormalizedSchema<R> = BaseNormalizedSchema<Elements, R>
 
 export interface NormalizedData {
   [entity: string]: Elements

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -26,10 +26,16 @@ export class Interpreter<M extends Model> {
   /**
    * Perform interpretation for the given data and return normalized schema.
    */
-  processRecord(data: Element | Element[]) {
+  processRecord(data: Element[]): [Element[], NormalizedData]
+  processRecord(data: Element): [Element, NormalizedData]
+  processRecord(
+    data: Element | Element[]
+  ): [Element | Element[], NormalizedData] {
     const schema = isArray(data) ? [this.getSchema()] : this.getSchema()
 
-    return normalize(data, schema)
+    const normalizedData = normalize(data, schema).entities as NormalizedData
+
+    return [data, normalizedData]
   }
 
   /**

--- a/src/interpreter/Interpreter.ts
+++ b/src/interpreter/Interpreter.ts
@@ -24,6 +24,15 @@ export class Interpreter<M extends Model> {
   }
 
   /**
+   * Perform interpretation for the given data and return normalized schema.
+   */
+  processRecord(data: Element | Element[]) {
+    const schema = isArray(data) ? [this.getSchema()] : this.getSchema()
+
+    return normalize(data, schema)
+  }
+
+  /**
    * Perform interpretation for the given data.
    */
   process(data: Element | Element[]): NormalizedData {

--- a/src/model/Model.ts
+++ b/src/model/Model.ts
@@ -597,4 +597,53 @@ export class Model {
       ? relation.map((model) => model.$toJson())
       : relation.$toJson()
   }
+
+  /**
+   * Sanitize the given record. This method is similar to `$toJson` method, but
+   * the difference is that it doesn't instantiate the full model. The method
+   * is used to sanitize the record before persisting to the store.
+   *
+   * It removes fields that don't exist in the model field schema or if the
+   * field is relationship fields.
+   *
+   * Note that this method only sanitizes existing fields in the given record.
+   * It will not generate missing model fields. If you need to generate all
+   * model fields, use `$sanitizeAndFill` method instead.
+   */
+  $sanitize(record: Element): Element {
+    const sanitizedRecord = {} as Element
+    const attrs = this.$fields()
+
+    for (const key in record) {
+      const attr = attrs[key]
+      const value = record[key]
+
+      if (attr !== undefined && !(attr instanceof Relation)) {
+        sanitizedRecord[key] = attr.make(value)
+      }
+    }
+
+    return sanitizedRecord
+  }
+
+  /**
+   * Same as `$sanitize` method, but it produces missing model fields with its
+   * default value.
+   */
+  $sanitizeAndFill(record: Element): Element {
+    const sanitizedRecord = {} as Element
+
+    const attrs = this.$fields()
+
+    for (const key in attrs) {
+      const attr = attrs[key]
+      const value = record[key]
+
+      if (!(attr instanceof Relation)) {
+        sanitizedRecord[key] = attr.make(value)
+      }
+    }
+
+    return sanitizedRecord
+  }
 }

--- a/src/modules/Mutations.ts
+++ b/src/modules/Mutations.ts
@@ -3,10 +3,18 @@ import { Elements } from '../data/Data'
 import { State } from './State'
 
 export interface Mutations<S extends State> extends MutationTree<S> {
+  save(state: S, records: Elements): void
   insert(state: S, records: Elements): void
   update(state: S, records: Elements): void
   delete(state: S, ids: string[]): void
   flush(state: S): void
+}
+
+/**
+ * Commit `save` change to the store.
+ */
+function save(state: State, callback: (data: Elements) => void): void {
+  callback(state.data)
 }
 
 /**
@@ -53,6 +61,7 @@ function flush(state: State): void {
 }
 
 export const mutations = {
+  save,
   insert,
   fresh,
   update,

--- a/src/modules/Mutations.ts
+++ b/src/modules/Mutations.ts
@@ -3,7 +3,7 @@ import { Elements } from '../data/Data'
 import { State } from './State'
 
 export interface Mutations<S extends State> extends MutationTree<S> {
-  save(state: S, records: Elements): void
+  save(state: S, callback: (data: Elements) => void): void
   insert(state: S, records: Elements): void
   update(state: S, records: Elements): void
   delete(state: S, ids: string[]): void

--- a/src/modules/Mutations.ts
+++ b/src/modules/Mutations.ts
@@ -3,7 +3,7 @@ import { Elements } from '../data/Data'
 import { State } from './State'
 
 export interface Mutations<S extends State> extends MutationTree<S> {
-  save(state: S, callback: (data: Elements) => void): void
+  save(state: S, records: Elements): void
   insert(state: S, records: Elements): void
   update(state: S, records: Elements): void
   delete(state: S, ids: string[]): void
@@ -13,8 +13,8 @@ export interface Mutations<S extends State> extends MutationTree<S> {
 /**
  * Commit `save` change to the store.
  */
-function save(state: State, callback: (data: Elements) => void): void {
-  callback(state.data)
+function save(state: State, records: Elements): void {
+  state.data = records
 }
 
 /**

--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -9,7 +9,6 @@ import {
 import {
   Element,
   Elements,
-  NormalizedSchema,
   NormalizedData,
   Item,
   Collection,
@@ -384,20 +383,22 @@ export class Query<M extends Model = Model> {
    * Retrieves the models from the store by following the given
    * normalized schema.
    */
-  revive(schema: NormalizedSchema<string>): Item<M>
-  revive(schema: NormalizedSchema<string[]>): Collection<M>
-  revive(schema: any): any {
-    const { result, entities } = schema
-
-    return isArray(result)
-      ? this.reviveMany(result, entities)
-      : this.reviveOne(result, entities)
+  revive(schema: Element[]): Collection<M>
+  revive(schema: Element): Item<M>
+  revive(schema: Element | Element[]): Item<M> | Collection<M> {
+    return isArray(schema) ? this.reviveMany(schema) : this.reviveOne(schema)
   }
 
   /**
    * Revive single model from the given schema.
    */
-  reviveOne(id: string, entities: NormalizedData, mark: any = {}): Item<M> {
+  reviveOne(schema: Element): Item<M> {
+    const id = schema.__id
+
+    if (!id) {
+      return null
+    }
+
     const item = this.connection.find(id)
 
     if (!item) {
@@ -406,11 +407,7 @@ export class Query<M extends Model = Model> {
 
     const model = this.hydrate(item)
 
-    const entity = entities[this.model.$entity()]?.[id]
-
-    if (entity) {
-      this.reviveRelations(model, entity, entities, mark)
-    }
+    this.reviveRelations(model, schema)
 
     return model
   }
@@ -418,9 +415,9 @@ export class Query<M extends Model = Model> {
   /**
    * Revive multiple models from the given schema.
    */
-  reviveMany(ids: string[], entities: NormalizedData, mark: any = {}): Collection<M> {
-    return ids.reduce<Collection<M>>((collection, id) => {
-      const model = this.reviveOne(id, entities, mark)
+  reviveMany(schema: Element[]): Collection<M> {
+    return schema.reduce<Collection<M>>((collection, item) => {
+      const model = this.reviveOne(item)
 
       model && collection.push(model)
 
@@ -442,46 +439,40 @@ export class Query<M extends Model = Model> {
   /**
    * Revive relations for the given schema and entity.
    */
-  protected reviveRelations(model: M, entity: Element, entities: NormalizedData, mark: any = {}) {
-    if (mark[model.$entity()]) {
-      return
-    }
-
+  protected reviveRelations(model: M, schema: Element) {
     const fields = this.model.$fields()
 
-    for (const key in entity) {
+    for (const key in schema) {
       const attr = fields[key]
 
       if (!(attr instanceof Relation)) {
         continue
       }
 
-      mark[model.$entity()] = true
+      const relatedSchema = schema[key]
 
-      const id = entity[key]
-
-      model[key] = isArray(id)
-        ? this.newQueryForRelation(attr).reviveMany(id, entities, mark)
-        : this.newQueryForRelation(attr).reviveOne(id, entities, mark)
+      model[key] = isArray(relatedSchema)
+        ? this.newQueryForRelation(attr).reviveMany(relatedSchema)
+        : this.newQueryForRelation(attr).reviveOne(relatedSchema)
     }
   }
 
   /**
    * Save the given records to the store with data normalization.
    */
-  save(record: Element): NormalizedSchema<string>
-  save(records: Element[]): NormalizedSchema<string[]>
-  save(records: any): any {
-    const schema = this.interpreter.processRecord(records)
+  save(records: Element[]): Element[]
+  save(record: Element): Element
+  save(records: Element | Element[]): Element | Element[] {
+    const [data, entities] = this.interpreter.processRecord(records)
 
-    for (const entity in schema.entities) {
+    for (const entity in entities) {
       const query = this.newQuery(entity)
-      const elements = schema.entities[entity]!
+      const elements = entities[entity]
 
       query.saveElements(elements)
     }
 
-    return schema
+    return data
   }
 
   /**

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -1,6 +1,6 @@
 import { Constructor } from '../types'
 import { assert } from '../support/Utils'
-import { Element, Item, Collection, Collections, NormalizedSchema } from '../data/Data'
+import { Element, Item, Collection, Collections } from '../data/Data'
 import { Database } from '../database/Database'
 import { Model } from '../model/Model'
 import { ModelConstructor } from '../model/ModelConstructor'
@@ -167,9 +167,9 @@ export class Repository<M extends Model = Model> {
    * Retrieves the models from the store by following the given
    * normalized schema.
    */
-  revive(schema: NormalizedSchema<string>): Item<M>
-  revive(schema: NormalizedSchema<string[]>): Collection<M>
-  revive(schema: any): any {
+  revive(schema: Element[]): Collection<M>
+  revive(schema: Element): Item<M>
+  revive(schema: Element | Element[]): Item<M> | Collection<M> {
     return this.query().revive(schema)
   }
 
@@ -187,9 +187,9 @@ export class Repository<M extends Model = Model> {
   /*
    * Save the given records to the store with data normalization.
    */
-  save(record: Element): NormalizedSchema<string>
-  save(records: Element[]): NormalizedSchema<string[]>
-  save(records: any): any {
+  save(records: Element[]): Element[]
+  save(record: Element): Element
+  save(records: Element | Element[]): Element | Element[] {
     return this.query().save(records)
   }
 

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -1,6 +1,6 @@
 import { Constructor } from '../types'
 import { assert } from '../support/Utils'
-import { Element, Item, Collection, Collections } from '../data/Data'
+import { Element, Item, Collection, Collections, NormalizedSchema } from '../data/Data'
 import { Database } from '../database/Database'
 import { Model } from '../model/Model'
 import { ModelConstructor } from '../model/ModelConstructor'
@@ -164,6 +164,16 @@ export class Repository<M extends Model = Model> {
   }
 
   /**
+   * Retrieves the models from the store by following the given
+   * normalized schema.
+   */
+  revive(schema: NormalizedSchema<string>): Item<M>
+  revive(schema: NormalizedSchema<string[]>): Collection<M>
+  revive(schema: any): any {
+    return this.query().revive(schema)
+  }
+
+  /**
    * Create a new model instance. This method will not save the model to the
    * store. It's pretty much the alternative to `new Model()`, but it injects
    * the store instance to support model instance methods in SSR environment.
@@ -172,6 +182,15 @@ export class Repository<M extends Model = Model> {
     return this.getModel().$newInstance(attributes, {
       relations: true
     })
+  }
+
+  /*
+   * Save the given records to the store with data normalization.
+   */
+  save(record: Element): NormalizedSchema<string>
+  save(records: Element[]): NormalizedSchema<string[]>
+  save(records: any): any {
+    return this.query().save(records)
   }
 
   /**

--- a/src/schema/Schema.ts
+++ b/src/schema/Schema.ts
@@ -87,7 +87,7 @@ export class Schema {
    */
   private idAttribute(
     model: Model,
-    parent: Model
+    _parent: Model
   ): Normalizr.StrategyFunction<string> {
     // We'll first check if the model contains any uid attributes. If so, we
     // generate the uids during the normalization process, so we'll keep that
@@ -95,12 +95,12 @@ export class Schema {
     // record, instead of looping through the model fields each time.
     const uidFields = this.getUidPrimaryKeyPairs(model)
 
-    return (record, parentRecord, key) => {
+    return (record, _parentRecord, key) => {
       // If the `key` is not `null`, that means this record is a nested
       // relationship of the parent model. In this case, we'll attach any
       // missing foreign keys to the record first.
       if (key !== null) {
-        ;(parent.$fields()[key] as Relation).attach(parentRecord, record)
+        // ;(parent.$fields()[key] as Relation).attach(parentRecord, record)
       }
 
       // Next, we'll generate any missing primary key fields defined as

--- a/test/feature/relations/has_many_retrieve.spec.ts
+++ b/test/feature/relations/has_many_retrieve.spec.ts
@@ -86,16 +86,11 @@ describe('feature/relations/has_many_retrieve', () => {
     })
 
     const schema = {
-      result: '1',
-      entities: {
-        users: {
-          1: { id: 1, posts: ['2', '1'] }
-        },
-        posts: {
-          1: { id: 1 },
-          2: { id: 2 }
-        }
-      }
+      __id: '1',
+      posts: [
+        { __id: 2 },
+        { __id: 1 }
+      ]
     }
 
     const user = store.$repo(User).revive(schema)!

--- a/test/feature/relations/has_many_retrieve.spec.ts
+++ b/test/feature/relations/has_many_retrieve.spec.ts
@@ -87,10 +87,7 @@ describe('feature/relations/has_many_retrieve', () => {
 
     const schema = {
       __id: '1',
-      posts: [
-        { __id: 2 },
-        { __id: 1 }
-      ]
+      posts: [{ __id: 2 }, { __id: 1 }]
     }
 
     const user = store.$repo(User).revive(schema)!

--- a/test/feature/relations/has_many_retrieve.spec.ts
+++ b/test/feature/relations/has_many_retrieve.spec.ts
@@ -71,4 +71,39 @@ describe('feature/relations/has_many_retrieve', () => {
       posts: []
     })
   })
+
+  it('can revive "has many" relations', () => {
+    const store = createStore()
+
+    fillState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' }
+      },
+      posts: {
+        1: { id: 1, userId: 1, title: 'Title 01' },
+        2: { id: 2, userId: 1, title: 'Title 02' }
+      }
+    })
+
+    const schema = {
+      result: '1',
+      entities: {
+        users: {
+          1: { id: 1, posts: ['2', '1'] }
+        },
+        posts: {
+          1: { id: 1 },
+          2: { id: 2 }
+        }
+      }
+    }
+
+    const user = store.$repo(User).revive(schema)!
+
+    expect(user.posts.length).toBe(2)
+    expect(user.posts[0]).toBeInstanceOf(Post)
+    expect(user.posts[1]).toBeInstanceOf(Post)
+    expect(user.posts[0].id).toBe(2)
+    expect(user.posts[1].id).toBe(1)
+  })
 })

--- a/test/feature/relations/has_many_save.spec.ts
+++ b/test/feature/relations/has_many_save.spec.ts
@@ -88,4 +88,27 @@ describe('feature/relations/has_many_save', () => {
       posts: {}
     })
   })
+
+  it('returns normalized schema when saving a model', () => {
+    const store = createStore()
+
+    const schema = store.$repo(User).save({
+      id: 1,
+      name: 'John Doe',
+      posts: [
+        { id: 1, userId: 1, title: 'Title 01' },
+        { id: 2, userId: 1, title: 'Title 02' }
+      ]
+    })
+
+    expect(schema).toEqual({
+      __id: '1',
+      id: 1,
+      name: 'John Doe',
+      posts: [
+        { __id: '1', id: 1, userId: 1, title: 'Title 01' },
+        { __id: '2', id: 2, userId: 1, title: 'Title 02' }
+      ]
+    })
+  })
 })

--- a/test/feature/relations/has_many_save.spec.ts
+++ b/test/feature/relations/has_many_save.spec.ts
@@ -1,0 +1,91 @@
+import { createStore, fillState, assertState } from 'test/Helpers'
+import { Model, Num, Str, HasMany } from '@/index'
+
+describe('feature/relations/has_many_save', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    @Num(0) id!: number
+    @Str('') name!: string
+
+    @HasMany(() => Post, 'userId')
+    posts!: Post[]
+  }
+
+  class Post extends Model {
+    static entity = 'posts'
+
+    @Num(0) id!: number
+    @Num(0) userId!: number
+    @Str('') title!: string
+  }
+
+  it('saves a model to the store with "has many" relation', () => {
+    const store = createStore()
+
+    fillState(store, {
+      users: {},
+      posts: {
+        1: { id: 1, userId: 1, title: 'Title 01' }
+      }
+    })
+
+    store.$repo(User).save({
+      id: 1,
+      name: 'John Doe',
+      posts: [
+        { id: 1, userId: 1, title: 100 },
+        { id: 2, userId: 1, title: 200 }
+      ]
+    })
+
+    assertState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' }
+      },
+      posts: {
+        1: { id: 1, userId: 1, title: '100' },
+        2: { id: 2, userId: 1, title: '200' }
+      }
+    })
+  })
+
+  it('generates missing foreign key', async () => {
+    const store = createStore()
+
+    await store.$repo(User).save({
+      id: 1,
+      name: 'John Doe',
+      posts: [
+        { id: 1, title: 'Title 01' },
+        { id: 2, title: 'Title 02' }
+      ]
+    })
+
+    assertState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' }
+      },
+      posts: {
+        1: { id: 1, userId: 1, title: 'Title 01' },
+        2: { id: 2, userId: 1, title: 'Title 02' }
+      }
+    })
+  })
+
+  it('can insert a record with missing relational key', async () => {
+    const store = createStore()
+
+    await store.$repo(User).save({
+      id: 1,
+      name: 'John Doe'
+    })
+
+    assertState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' }
+      },
+      posts: {}
+    })
+  })
+})

--- a/test/feature/relations/nested/nested_revive.spec.ts
+++ b/test/feature/relations/nested/nested_revive.spec.ts
@@ -1,0 +1,94 @@
+import { createStore, fillState } from 'test/Helpers'
+import { Model, Attr, BelongsTo, HasMany } from '@/index'
+
+describe('feature/relations/nested/nested_revive', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    @Attr() id!: number
+
+    @HasMany(() => Post, 'userId')
+    posts!: Post[]
+  }
+
+  class Post extends Model {
+    static entity = 'posts'
+
+    @Attr() id!: number
+    @Attr() userId!: number | null
+
+    @BelongsTo(() => User, 'userId')
+    author!: User | null
+
+    @HasMany(() => Comment, 'postId')
+    comments!: Comment[]
+  }
+
+  class Comment extends Model {
+    static entity = 'comments'
+
+    @Attr() id!: number
+    @Attr() postId!: number
+    @Attr() userId!: number
+
+    @BelongsTo(() => User, 'userId')
+    author!: User | null
+  }
+
+  it('can revive a complex nested schema', () => {
+    const store = createStore()
+
+    fillState(store, {
+      users: {
+        1: { id: 1 },
+        2: { id: 2 },
+        3: { id: 3 },
+        4: { id: 4 }
+      },
+      posts: {
+        1: { id: 1, userId: 2 },
+        2: { id: 2, userId: 2 },
+        3: { id: 3, userId: 1 },
+        4: { id: 4, userId: 1 }
+      },
+      comments: {
+        1: { id: 1, postId: 4, userId: 4 },
+        2: { id: 2, postId: 1, userId: 2 },
+        3: { id: 3, postId: 2, userId: 3 },
+        4: { id: 4, postId: 4, userId: 3 },
+        5: { id: 5, postId: 2, userId: 1 }
+      }
+    })
+
+    const schema = {
+      result: ['2', '1'],
+      entities: {
+        users: {
+          1: { id: 1, posts: ['4', '3'] },
+          2: { id: 2, posts: ['1', '2'] },
+          3: { id: 3 },
+          4: { id: 4 }
+        },
+        posts: {
+          1: { id: 1, userId: 2, comments: ['2'] },
+          2: { id: 2, userId: 2, comments: ['3', '5'] },
+          3: { id: 3, userId: 1, comments: [] },
+          4: { id: 4, userId: 1, comments: ['4', '1'] }
+        },
+        comments: {
+          1: { id: 1, postId: 4, userId: 4, author: '4' },
+          2: { id: 2, postId: 1, userId: 2, author: '2' },
+          3: { id: 3, postId: 2, userId: 3, author: '3' },
+          4: { id: 4, postId: 4, userId: 3, author: '3' },
+          5: { id: 5, postId: 2, userId: 1, author: '1' }
+        }
+      }
+    }
+
+    const users = store.$repo(User).revive(schema)
+console.log(users)
+    expect(users.length).toBe(2)
+    expect(users[0].posts.length).toBe(2)
+    expect(users[1].posts.length).toBe(2)
+  })
+})

--- a/test/feature/relations/nested/nested_revive.spec.ts
+++ b/test/feature/relations/nested/nested_revive.spec.ts
@@ -60,35 +60,40 @@ describe('feature/relations/nested/nested_revive', () => {
       }
     })
 
-    const schema = {
-      result: ['2', '1'],
-      entities: {
-        users: {
-          1: { id: 1, posts: ['4', '3'] },
-          2: { id: 2, posts: ['1', '2'] },
-          3: { id: 3 },
-          4: { id: 4 }
-        },
-        posts: {
-          1: { id: 1, userId: 2, comments: ['2'] },
-          2: { id: 2, userId: 2, comments: ['3', '5'] },
-          3: { id: 3, userId: 1, comments: [] },
-          4: { id: 4, userId: 1, comments: ['4', '1'] }
-        },
-        comments: {
-          1: { id: 1, postId: 4, userId: 4, author: '4' },
-          2: { id: 2, postId: 1, userId: 2, author: '2' },
-          3: { id: 3, postId: 2, userId: 3, author: '3' },
-          4: { id: 4, postId: 4, userId: 3, author: '3' },
-          5: { id: 5, postId: 2, userId: 1, author: '1' }
-        }
+    const schema = [
+      {
+        __id: 2,
+        posts: [
+          {
+            __id: 4,
+            comments: [{ __id: 2 }]
+          },
+          {
+            __id: 3,
+            comments: [
+              {
+                __id: 1,
+                author: { __id: 4 }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        __id: 1,
+        posts: [{ __id: 1 }, { __id: 2 }]
       }
-    }
+    ]
 
     const users = store.$repo(User).revive(schema)
-console.log(users)
+
     expect(users.length).toBe(2)
+    expect(users[0].id).toBe(2)
+    expect(users[1].id).toBe(1)
     expect(users[0].posts.length).toBe(2)
-    expect(users[1].posts.length).toBe(2)
+    expect(users[0].posts[0].comments.length).toBe(1)
+    expect(users[0].posts[0].comments[0].id).toBe(2)
+    expect(users[0].posts[1].comments.length).toBe(1)
+    expect(users[0].posts[1].comments[0].id).toBe(1)
   })
 })

--- a/test/feature/repository/retrieves_revive.spec.ts
+++ b/test/feature/repository/retrieves_revive.spec.ts
@@ -21,8 +21,7 @@ describe('feature/repository/retrieves_revive', () => {
     })
 
     const schema = {
-      result: '2',
-      entities: {}
+      __id: 2
     }
 
     const user = store.$repo(User).revive(schema)!
@@ -31,7 +30,7 @@ describe('feature/repository/retrieves_revive', () => {
     expect(user.id).toBe(2)
   })
 
-  it('returns null if result can not be found', () => {
+  it('returns null if result can not be found when passing object schema', () => {
     const store = createStore()
 
     fillState(store, {
@@ -42,17 +41,14 @@ describe('feature/repository/retrieves_revive', () => {
       }
     })
 
-    const schema = {
-      result: '4',
-      entities: {}
-    }
+    // Test missing id in the store.
+    expect(store.$repo(User).revive({ __id: 4 })).toBe(null)
 
-    const user = store.$repo(User).revive(schema)
-
-    expect(user).toBe(null)
+    // Test missing id in the schema.
+    expect(store.$repo(User).revive({})).toBe(null)
   })
 
-  it('retrieves models from the store by the given schema', () => {
+  it('retrieves multiple models from the store by the given schema', () => {
     const store = createStore()
 
     fillState(store, {
@@ -63,10 +59,7 @@ describe('feature/repository/retrieves_revive', () => {
       }
     })
 
-    const schema = {
-      result: ['3', '1'],
-      entities: {}
-    }
+    const schema = [{ __id: 3 }, { __id: 1 }]
 
     const users = store.$repo(User).revive(schema)
 

--- a/test/feature/repository/retrieves_revive.spec.ts
+++ b/test/feature/repository/retrieves_revive.spec.ts
@@ -1,0 +1,77 @@
+import { createStore, fillState } from 'test/Helpers'
+import { Model, Num, Str } from '@/index'
+
+describe('feature/repository/retrieves_revive', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    @Num(0) id!: number
+    @Str('') name!: string
+  }
+
+  it('retrieves a model from the store by the given schema', () => {
+    const store = createStore()
+
+    fillState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' },
+        2: { id: 2, name: 'Jane Doe' },
+        3: { id: 3, name: 'Johnny Doe' }
+      }
+    })
+
+    const schema = {
+      result: '2',
+      entities: {}
+    }
+
+    const user = store.$repo(User).revive(schema)!
+
+    expect(user).toBeInstanceOf(User)
+    expect(user.id).toBe(2)
+  })
+
+  it('returns null if result can not be found', () => {
+    const store = createStore()
+
+    fillState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' },
+        2: { id: 2, name: 'Jane Doe' },
+        3: { id: 3, name: 'Johnny Doe' }
+      }
+    })
+
+    const schema = {
+      result: '4',
+      entities: {}
+    }
+
+    const user = store.$repo(User).revive(schema)
+
+    expect(user).toBe(null)
+  })
+
+  it('retrieves models from the store by the given schema', () => {
+    const store = createStore()
+
+    fillState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe' },
+        2: { id: 2, name: 'Jane Doe' },
+        3: { id: 3, name: 'Johnny Doe' }
+      }
+    })
+
+    const schema = {
+      result: ['3', '1'],
+      entities: {}
+    }
+
+    const users = store.$repo(User).revive(schema)
+
+    expect(users.length).toBe(2)
+    expect(users[0].id).toBe(3)
+    expect(users[1].id).toBe(1)
+  })
+})

--- a/test/feature/repository/save.spec.ts
+++ b/test/feature/repository/save.spec.ts
@@ -1,0 +1,124 @@
+import { createStore, fillState, assertState } from 'test/Helpers'
+import { Model, Str, Num } from '@/index'
+
+describe('feature/repository/save', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    @Num(0) id!: number
+    @Str('') name!: string
+    @Num(0) age!: number
+  }
+
+  it('does nothing when passing in an empty array', () => {
+    const store = createStore()
+
+    store.$repo(User).save([])
+
+    assertState(store, {
+      users: {}
+    })
+  })
+
+  it('saves a model to the store', () => {
+    const store = createStore()
+
+    store.$repo(User).save({ id: 1, name: 'John Doe', age: 30 })
+
+    assertState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 }
+      }
+    })
+  })
+
+  it('saves multiple models to the store', () => {
+    const store = createStore()
+
+    store.$repo(User).save([
+      { id: 1, name: 'John Doe', age: 30 },
+      { id: 2, name: 'Jane Doe', age: 20 }
+    ])
+
+    assertState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 },
+        2: { id: 2, name: 'Jane Doe', age: 20 }
+      }
+    })
+  })
+
+  it('updates existing model if it exists when saving a model', () => {
+    const store = createStore()
+
+    fillState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 }
+      }
+    })
+
+    store.$repo(User).save({ id: 1, age: 20 })
+
+    assertState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe', age: 20 }
+      }
+    })
+  })
+
+  it('updates existing model if it exists when saving multiple model', () => {
+    const store = createStore()
+
+    fillState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe', age: 30 }
+      }
+    })
+
+    store.$repo(User).save([
+      { id: 1, age: 20 },
+      { id: 2, name: 'Jane Doe', age: 10 }
+    ])
+
+    assertState(store, {
+      users: {
+        1: { id: 1, name: 'John Doe', age: 20 },
+        2: { id: 2, name: 'Jane Doe', age: 10 }
+      }
+    })
+  })
+
+  it('returns normalized schema when saving a model', () => {
+    const store = createStore()
+
+    const schema = store.$repo(User).save({ id: 1, name: 'John Doe', age: 30 })
+
+    expect(schema).toEqual({
+      result: '1',
+      entities: {
+        users: {
+          1: { id: 1, name: 'John Doe', age: 30 }
+        }
+      }
+    })
+  })
+
+  it('returns normalized schema when saving multiple models', () => {
+    const store = createStore()
+
+    const schema = store.$repo(User).save([
+      { id: 1, name: 'John Doe', age: 30 },
+      { id: 2, name: 'Jane Doe', age: 20 }
+    ])
+
+    expect(schema).toEqual({
+      result: ['1', '2'],
+      entities: {
+        users: {
+          1: { id: 1, name: 'John Doe', age: 30 },
+          2: { id: 2, name: 'Jane Doe', age: 20 }
+        }
+      }
+    })
+  })
+})

--- a/test/feature/repository/save.spec.ts
+++ b/test/feature/repository/save.spec.ts
@@ -94,12 +94,10 @@ describe('feature/repository/save', () => {
     const schema = store.$repo(User).save({ id: 1, name: 'John Doe', age: 30 })
 
     expect(schema).toEqual({
-      result: '1',
-      entities: {
-        users: {
-          1: { id: 1, name: 'John Doe', age: 30 }
-        }
-      }
+      __id: '1',
+      id: 1,
+      name: 'John Doe',
+      age: 30
     })
   })
 
@@ -111,14 +109,9 @@ describe('feature/repository/save', () => {
       { id: 2, name: 'Jane Doe', age: 20 }
     ])
 
-    expect(schema).toEqual({
-      result: ['1', '2'],
-      entities: {
-        users: {
-          1: { id: 1, name: 'John Doe', age: 30 },
-          2: { id: 2, name: 'Jane Doe', age: 20 }
-        }
-      }
-    })
+    expect(schema).toEqual([
+      { __id: '1', id: 1, name: 'John Doe', age: 30 },
+      { __id: '2', id: 2, name: 'Jane Doe', age: 20 }
+    ])
   })
 })

--- a/test/unit/model/Model_Sanitize.spec.ts
+++ b/test/unit/model/Model_Sanitize.spec.ts
@@ -1,0 +1,54 @@
+import { HasMany } from '@/model/decorators/attributes/relations/HasMany'
+import { Num } from '@/model/decorators/attributes/types/Num'
+import { Str } from '@/model/decorators/attributes/types/Str'
+import { Model } from '@/model/Model'
+import { createStore } from 'test/Helpers'
+
+describe('unit/model/Model_Sanitize', () => {
+  class User extends Model {
+    static entity = 'users'
+
+    @Num(null, { nullable: true }) id!: number
+    @Str('Unknown') name!: string
+    @Num(0) age!: number
+
+    @HasMany(() => Post, 'postId')
+    posts!: Post[]
+  }
+
+  class Post extends Model {
+    static entity = 'posts'
+  }
+
+  it('sanitizes the given record', () => {
+    const user = createStore().$repo(User).make()
+
+    const data = user.$sanitize({
+      id: 1,
+      unknownField: 1,
+      age: '10',
+      posts: [1, 3]
+    })
+
+    const expected = {
+      id: 1,
+      age: 10
+    }
+
+    expect(data).toEqual(expected)
+  })
+
+  it('sanitize the given record and fill missing fields', () => {
+    const user = createStore().$repo(User).make()
+
+    const data = user.$sanitizeAndFill({ id: 1, posts: [1, 3] })
+
+    const expected = {
+      id: 1,
+      name: 'Unknown',
+      age: 0
+    }
+
+    expect(data).toEqual(expected)
+  })
+})


### PR DESCRIPTION
ref #60 

This PR adds 2 new method to the repository. `save` and `revive`.

#### Type of PR:

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Code style update
- [x] Build-related changes
- [ ] Test
- [ ] Documentation
- [ ] Other, please describe:

#### Breaking changes:

- [x] No
- [ ] Yes

### Details

The `save` method will insert a given data, or update it if it already exists in the store. It will also normalize any relationships as well.

```js
userRepo.save({ id: 1, name: 'John Doe' })
```

The save method will return something we call `schema`, which is the original data passed into the `save` method, but with special `__id` key attached.

```js
const data = {
  id: 1,
  posts: [
    { id: 2, userId: 1 },
    { id: 1, userId: 1 }
  ]
}

const schema = userRepo.save(data)
/*
  {
    __id: '1', // <- Attached!
    id: 1,
    posts: [
      { __id: '2', id: 2, userId: 1 }, // <- Attached!
      { __id: '1', id: 1, userId: 1 }  // <- Attached!
    ]
  }
*/
```

We may now pass this `schema` to the new `revive` method to retrieve the models.

```js
const user = userRepo.revive(schema)
/*
  User {
    id: 1,
    posts: [
      Post { id: 2, userId: 1 },
      Post { id: 1, userId: 1 }
    ]
  }
*/
```

All of the relationship will be correctly resolved. Also, note that the order of the `posts` relationships are well preserved.

Combining `save` and `revive` method, we can easily reuse the record order that external apis might had, while normalizing the data and saving it to the store.

### Todos

- [x] Resolve TODO comments