### PR TITLE
feat: add the `new` method to create and persist entry with default values (#57)

### DIFF
--- a/src/query/Query.ts
+++ b/src/query/Query.ts
@@ -380,6 +380,17 @@ export class Query<M extends Model = Model> {
   }
 
   /**
+   * Create and persist model with default values.
+   */
+  async new(): Promise<M> {
+    const model = this.model.$newInstance(undefined, { relations: false })
+
+    this.connection.insert(this.compile(model))
+
+    return model
+  }
+
+  /**
    * Insert the given record to the store.
    */
   async insert(records: Element | Element[]): Promise<Collections> {

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -175,6 +175,13 @@ export class Repository<M extends Model = Model> {
   }
 
   /**
+   * Create and persist model with default values.
+   */
+  new(): Promise<M> {
+    return this.query().new()
+  }
+
+  /**
    * Insert the given records to the store.
    */
   insert(records: Element | Element[]): Promise<Collections> {

--- a/test/feature/repository/inserts_new.spec.ts
+++ b/test/feature/repository/inserts_new.spec.ts
@@ -1,0 +1,40 @@
+import { createStore, assertState, mockUid } from 'test/Helpers'
+import { Model, Str, Num, Bool, Uid, Attr } from '@/index'
+
+describe('feature/repository/inserts_new', () => {
+  it('inserts with a models default values', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Uid() id!: string
+      @Str('John Doe') name!: string
+      @Num(21) age!: number
+      @Bool(true) active!: boolean
+    }
+
+    mockUid(['uid1'])
+
+    const store = createStore()
+
+    await store.$repo(User).new()
+
+    assertState(store, {
+      users: {
+        uid1: { id: 'uid1', name: 'John Doe', age: 21, active: true }
+      }
+    })
+  })
+
+  it('throws if a primary key is not capable of being generated', async () => {
+    class User extends Model {
+      static entity = 'users'
+
+      @Attr() id!: string
+      @Str('John Doe') name!: string
+    }
+
+    const store = createStore()
+
+    await expect(() => store.$repo(User).new()).rejects.toThrow()
+  })
+})

--- a/test/feature/repository/inserts_new.spec.ts
+++ b/test/feature/repository/inserts_new.spec.ts
@@ -29,7 +29,7 @@ describe('feature/repository/inserts_new', () => {
     class User extends Model {
       static entity = 'users'
 
-      @Attr() id!: string
+      @Attr() id!: any
       @Str('John Doe') name!: string
     }
 


### PR DESCRIPTION
closes #57 

#### Type of PR:

- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Code style update
- [ ] Build-related changes
- [x] Test
- [ ] Documentation
- [ ] Other, please describe:

#### Breaking changes:

- [x] No
- [ ] Yes

### Details

Similar to `make()`, but with persistence, this PR adds the `new()` method to the `Repository` and `Query` APIs to create and persist a data entry with default-only values.