### PR TITLE
Remove `as any` from relations

### DIFF
--- a/src/model/attributes/relations/BelongsTo.ts
+++ b/src/model/attributes/relations/BelongsTo.ts
@@ -65,7 +65,7 @@ export class BelongsTo extends Relation {
    * Set the constraints for an eager load of the relation.
    */
   addEagerConstraints(query: Query, models: Collection): void {
-    query.whereIn(this.ownerKey as any, this.getEagerModelKeys(models))
+    query.whereIn(this.ownerKey, this.getEagerModelKeys(models))
   }
 
   /**

--- a/src/model/attributes/relations/HasMany.ts
+++ b/src/model/attributes/relations/HasMany.ts
@@ -55,7 +55,7 @@ export class HasMany extends Relation {
    * Set the constraints for an eager load of the relation.
    */
   addEagerConstraints(query: Query, models: Collection): void {
-    query.whereIn(this.foreignKey as any, this.getKeys(models, this.localKey))
+    query.whereIn(this.foreignKey, this.getKeys(models, this.localKey))
   }
 
   /**

--- a/src/model/attributes/relations/HasOne.ts
+++ b/src/model/attributes/relations/HasOne.ts
@@ -55,7 +55,7 @@ export class HasOne extends Relation {
    * Set the constraints for an eager load of the relation.
    */
   addEagerConstraints(query: Query, models: Collection): void {
-    query.whereIn(this.foreignKey as any, this.getKeys(models, this.localKey))
+    query.whereIn(this.foreignKey, this.getKeys(models, this.localKey))
   }
 
   /**


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->

<!-- Please describe a summary of this PR. -->

#### Type of PR:

- [ ] Bugfix
- [ ] Feature
- [x] Refactor
- [ ] Code style update
- [ ] Build-related changes
- [ ] Test
- [ ] Documentation
- [ ] Other, please describe:

#### Breaking changes:

- [x] No
- [ ] Yes

### Details

<!-- Please describe the details of the PR. -->

Context: https://github.com/vuex-orm/vuex-orm-next/pull/91/files/5c1a11779811408f0caf6dd30bb9b28245e90792#r744380891

Removing `as any` from relation `addEagerConstraints` method as it is no longer required because trying to type hint the `where` query was found to be nearly impossible.
